### PR TITLE
chore: jenkinsx-on-prem-python-2 to 0.0.29

### DIFF
--- a/requirements.yaml
+++ b/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: jenkinsx-on-prem-python-2
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.28
+  version: 0.0.29


### PR DESCRIPTION
chore: Promote jenkinsx-on-prem-python-2 to version 0.0.29